### PR TITLE
Remove integration api param from registration method

### DIFF
--- a/TwilioAuthenticatorSample/Registration/RegisterDeviceViewController.m
+++ b/TwilioAuthenticatorSample/Registration/RegisterDeviceViewController.m
@@ -147,7 +147,7 @@
 
 - (void)registerDeviceWithAuthyWithRegistrationToken:(NSString *)registrationToken andPushToken:(NSString *)pushToken {
 
-    [self.sharedTwilioAuth registerDeviceWithRegistrationToken:registrationToken integrationApiKey:nil pushToken:pushToken completion:^(NSError *error) {
+    [self.sharedTwilioAuth registerDeviceWithRegistrationToken:registrationToken pushToken:pushToken completion:^(NSError *error) {
 
         if (error != nil) {
 


### PR DESCRIPTION
## Changes
Remove integration api param from registration method

## Checklist
- [ ] Did you run the tests?
- [x] Did you add the labels? (hotfix, vulnerability, new-feature, task, ui, needs-security-review)
- [x] Is new code covered?
- [ ] Is code instrumented?
- [x] New fields validated?
- [x] User inputs validated?
- [x] All errors handled?
- [x] Enough logging?
